### PR TITLE
drop dependency of node-json-minify, use JSON.stringify to minify json

### DIFF
--- a/minify.js
+++ b/minify.js
@@ -6,7 +6,6 @@ var onHeaders = require('on-headers');
 
 var uglifyjs = require('uglify-js');
 var cssmin = require('cssmin');
-var jsonMinify = require("node-json-minify");
 var sass;
 var less;
 var stylus;
@@ -135,7 +134,7 @@ function minifyIt(type, options, content, callback) {
     result = content;
     try {
       if (!options.noMinify) {
-        result = jsonMinify(content);
+        result = JSON.stringify(JSON.parse(content));
       }
     } catch (ignore) {
     }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "coffee-script": "^1.9.2",
     "cssmin": "^0.4.3",
     "less": "^2.5.0",
-    "node-json-minify": "^0.1.3-a",
     "node-sass": "^3.1.1",
     "on-headers": "^1.0.0",
     "stylus": "^0.51.1",

--- a/test/test.js
+++ b/test/test.js
@@ -14,7 +14,6 @@ var sass = require('node-sass');
 var less = require('less');
 var stylus = require('stylus');
 var coffee = require('coffee-script');
-JSON.minify = require("node-json-minify");
 
 var expectation = {
   'js': [
@@ -272,7 +271,7 @@ function init(callback) {
   minifyFunc.json = function(content, callback) {
     callback({
       processed: content,
-      minified: JSON.minify(content)
+      minified: JSON.stringify(JSON.parse(content))
     });
   }
 


### PR DESCRIPTION
node-json-minify will have performance issue with large json files, make nodejs hangs and the cpu usage been 100% ... JSON.stringify works fine without that problem.