### PR TITLE
Bump uglify-js to v2.6.1 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "cssmin": "^0.4.3",
     "on-headers": "^1.0.0",
-    "uglify-js": "^2.4.24"
+    "uglify-js": "^2.6.1"
   },
   "devDependencies": {
     "async": "^1.4.2",


### PR DESCRIPTION
uglify-js versions less then 2.6.0 have security issue here:
https://nodesecurity.io/advisories/uglify-js_regular-expression-denial-of-service